### PR TITLE
Adds queue name

### DIFF
--- a/dpq/migrations/0003_adds_queue_field.py
+++ b/dpq/migrations/0003_adds_queue_field.py
@@ -8,7 +8,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AlterField(
+        migrations.AddField(
             model_name="job",
             name="queue",
             field=models.CharField(

--- a/dpq/migrations/0003_adds_queue_field.py
+++ b/dpq/migrations/0003_adds_queue_field.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("dpq", "0002_auto_20190419_2057"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="job",
+            name="queue",
+            field=models.CharField(
+                max_length=32,
+                default="default",
+                help_text="Use a unique name to represent each queue.",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="job",
+            index=models.Index(fields=["queue"], name="dpq_job_queue_aa4927_idx"),
+        ),
+    ]

--- a/dpq/models.py
+++ b/dpq/models.py
@@ -2,6 +2,8 @@ from django.db import models
 from django.contrib.postgres.functions import TransactionNow
 from django.contrib.postgres.fields import JSONField
 
+DEFAULT_QUEUE_NAME = "default"
+
 
 class Job(models.Model):
     id = models.BigAutoField(primary_key=True)
@@ -13,17 +15,23 @@ class Job(models.Model):
     )
     task = models.CharField(max_length=255)
     args = JSONField()
+    queue = models.CharField(
+        max_length=32,
+        default=DEFAULT_QUEUE_NAME,
+        help_text="Use a unique name to represent each queue.",
+    )
 
     class Meta:
         indexes = [
-            models.Index(fields=['-priority', 'created_at']),
+            models.Index(fields=["-priority", "created_at"]),
+            models.Index(fields=["queue"]),
         ]
 
     def __str__(self):
         return '%s: %s' % (self.id, self.task)
 
     @classmethod
-    def dequeue(cls, exclude_ids=[]):
+    def dequeue(cls, exclude_ids=[], queue=DEFAULT_QUEUE_NAME):
         """
         Claims the first available task and returns it. If there are no
         tasks available, returns None.
@@ -43,6 +51,7 @@ class Job(models.Model):
                 SELECT id
                 FROM dpq_job
                 WHERE execute_at <= now()
+                  AND queue = %s
                   AND NOT id = ANY(%s)
                 ORDER BY priority DESC, created_at
                 FOR UPDATE SKIP LOCKED
@@ -50,8 +59,9 @@ class Job(models.Model):
             )
             RETURNING *;
             """,
-            [list(exclude_ids)]
-        ))
+                [queue, list(exclude_ids)],
+            )
+        )
         assert len(tasks) <= 1
         if tasks:
             return tasks[0]
@@ -60,10 +70,11 @@ class Job(models.Model):
 
     def to_json(self):
         return {
-            'id': self.id,
-            'created_at': self.created_at,
-            'execute_at': self.execute_at,
-            'priority': self.priority,
-            'task': self.task,
-            'args': self.args,
+            "id": self.id,
+            "created_at": self.created_at,
+            "execute_at": self.execute_at,
+            "priority": self.priority,
+            "queue": self.queue,
+            "task": self.task,
+            "args": self.args,
         }

--- a/dpq/tests.py
+++ b/dpq/tests.py
@@ -4,16 +4,17 @@ from .models import Job, DEFAULT_QUEUE_NAME
 from .queue import AtLeastOnceQueue
 
 
-class DpqQueueTests(TestCase):
-    def demotask(queue, job):
-        return job.id
+def demotask(queue, job):
+    return job.id
 
+
+class DpqQueueTests(TestCase):
     def test_create_job_on_queue(self):
         """
         Creates a basic queue with a name, and puts the job onto the queue.
         """
         NAME = "machine_a"
-        queue = AtLeastOnceQueue(tasks=["demotask"], queue=NAME)
+        queue = AtLeastOnceQueue(tasks={"demotask": demotask}, queue=NAME)
 
         queue.enqueue("demotask", {"count": 5})
         job = Job.dequeue(queue=queue.queue)
@@ -25,10 +26,10 @@ class DpqQueueTests(TestCase):
         Test that a job added to one queue won't be visible on another queue.
         """
         NAME = "machine_a"
-        queue = AtLeastOnceQueue(tasks=["demotask"], queue=NAME)
+        queue = AtLeastOnceQueue(tasks={"demotask": demotask}, queue=NAME)
 
         NAME2 = "machine_b"
-        queue2 = AtLeastOnceQueue(tasks=["demotask"], queue=NAME2)
+        queue2 = AtLeastOnceQueue(tasks={"demotask": demotask}, queue=NAME2)
 
         queue.enqueue("demotask", {"count": 5})
         job = Job.dequeue(queue=queue2.queue)
@@ -41,7 +42,7 @@ class DpqQueueTests(TestCase):
         """
         Test jobs can be added without a queue name defined.
         """
-        queue = AtLeastOnceQueue(tasks=["demotask"])
+        queue = AtLeastOnceQueue(tasks={"demotask": demotask})
 
         queue.enqueue("demotask", {"count": 5})
         job = Job.dequeue(queue=queue.queue)
@@ -50,9 +51,9 @@ class DpqQueueTests(TestCase):
 
     def test_same_name_queues_can_fetch_tasks(self):
         NAME = "machine_a"
-        queue = AtLeastOnceQueue(tasks=["demotask"], queue=NAME)
+        queue = AtLeastOnceQueue(tasks={"demotask": demotask}, queue=NAME)
 
-        queue2 = AtLeastOnceQueue(tasks=["demotask"], queue=NAME)
+        queue2 = AtLeastOnceQueue(tasks={"demotask": demotask}, queue=NAME)
 
         queue.enqueue("demotask", {"count": 5})
         job = Job.dequeue(queue=queue2.queue)

--- a/dpq/tests.py
+++ b/dpq/tests.py
@@ -1,3 +1,21 @@
 from django.test import TestCase
 
-# Create your tests here.
+from .models import Job
+from .queue import AtLeastOnceQueue
+
+
+class DpqQueueTests(TestCase):
+    def demotask(queue, job):
+        return job.id
+
+    def test_create_job_on_queue(self):
+        """
+        Creates a basic queue with a name, and puts the job onto the queue.
+        """
+        NAME = "machine_a"
+        queue = AtLeastOnceQueue(tasks=["demotask"], queue=NAME)
+
+        queue.enqueue("demotask", {"count": 5})
+        job = Job.dequeue(queue=queue.queue)
+        self.assertEqual(job.args["count"], 5)
+        self.assertEqual(job.queue, NAME)

--- a/dpq/tests.py
+++ b/dpq/tests.py
@@ -47,3 +47,18 @@ class DpqQueueTests(TestCase):
         job = Job.dequeue(queue=queue.queue)
         self.assertEqual(job.args["count"], 5)
         self.assertEqual(job.queue, DEFAULT_QUEUE_NAME)
+
+    def test_same_name_queues_can_fetch_tasks(self):
+        NAME = "machine_a"
+        queue = AtLeastOnceQueue(tasks=["demotask"], queue=NAME)
+
+        queue2 = AtLeastOnceQueue(tasks=["demotask"], queue=NAME)
+
+        queue.enqueue("demotask", {"count": 5})
+        job = Job.dequeue(queue=queue2.queue)
+        # job is dequeued..
+        self.assertNotEqual(job, None)
+
+        # now the job should be gone...
+        job = Job.dequeue(queue=queue.queue)
+        self.assertEqual(job, None)

--- a/testproj/settings.py
+++ b/testproj/settings.py
@@ -78,9 +78,12 @@ WSGI_APPLICATION = 'testproj.wsgi.application'
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'dpq_testproj',
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": "dpq_testproj",
+        "USER": "dpq",
+        "PASSWORD": "dpq",
+        "TEST": {"NAME": "dpq_testproj"},
     }
 }
 

--- a/testproj/settings.py
+++ b/testproj/settings.py
@@ -124,12 +124,12 @@ USE_TZ = True
 STATIC_URL = '/static/'
 
 LOGGING = {
-    'version': 1,
-    'handlers': {
-        'console': {
-            'class': 'logging.StreamHandler',
-            'level': 'DEBUG',
-            'formatter': 'verbose',
+    "version": 1,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "level": "WARN",
+            "formatter": "verbose",
         },
     },
     'formatters': {


### PR DESCRIPTION
Queue names can be used to namespace jobs. E.g. some jobs get run on
machine A, others get run on machine B

They can also help prevent a situation where slow tasks choke the
available workers.

Queues and priorities are a perfect match