### PR TITLE
Keyerror multi queue

### DIFF
--- a/dpq/queue.py
+++ b/dpq/queue.py
@@ -82,7 +82,7 @@ class Queue(object, metaclass=abc.ABCMeta):
             cur.execute('NOTIFY "{}", %s;'.format(self.notify_channel), [str(job.pk)])
 
     def _run_once(self, exclude_ids=[]):
-        job = self.job_model.dequeue(exclude_ids=exclude_ids)
+        job = self.job_model.dequeue(exclude_ids=exclude_ids, tasks=list(self.tasks))
         if job:
             self.logger.debug('Claimed %r.', job, extra={
                 'data': {

--- a/dpq/test_queues.py
+++ b/dpq/test_queues.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 
+from .models import Job
 from .queue import AtLeastOnceQueue
 
 
@@ -15,9 +16,15 @@ class DpqMultipleQueueTests(TestCase):
         gets a job meant for a different queue
         """
 
-        queue1 = AtLeastOnceQueue(tasks={"task1": demotask})
-        queue2 = AtLeastOnceQueue(tasks={"task2": demotask})
+        queue1 = AtLeastOnceQueue(tasks={"task1": demotask, "task3": demotask})
+        queue2 = AtLeastOnceQueue(tasks={"task2": demotask, "task4": demotask})
 
         queue1.enqueue("task1", {"count": 5})
 
         queue2.run_once()
+
+    def test_dequeue_without_tasks(self):
+        """
+        Check that a job can dequeue without any tasks given.
+        """
+        Job.dequeue()

--- a/dpq/test_queues.py
+++ b/dpq/test_queues.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+
+from .queue import AtLeastOnceQueue
+
+
+def demotask(queue, job):
+    return job.id
+
+
+class DpqMultipleQueueTests(TestCase):
+    def test_multiple_queues_mutually_exclusive_tasks(self):
+        """
+        Test for a bug where defining multiple queues
+        with exclusive tasks raises KeyError when a worker for one queue
+        gets a job meant for a different queue
+        """
+
+        queue1 = AtLeastOnceQueue(tasks={"task1": demotask})
+        queue2 = AtLeastOnceQueue(tasks={"task2": demotask})
+
+        queue1.enqueue("task1", {"count": 5})
+
+        queue2.run_once()

--- a/testproj/settings.py
+++ b/testproj/settings.py
@@ -78,9 +78,12 @@ WSGI_APPLICATION = 'testproj.wsgi.application'
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'dpq_testproj',
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": "dpq_testproj",
+        "USER": "dpq",
+        "PASSWORD": "dpq",
+        "TEST": {"NAME": "dpq_testproj"},
     }
 }
 


### PR DESCRIPTION
fix for #8 

Test case shows that naive queue can fetch even tasks that it cannot handle. In those cases it raises KeyError.