### PR TITLE
Run worker with django autoreloader by default

### DIFF
--- a/dpq/commands.py
+++ b/dpq/commands.py
@@ -90,6 +90,9 @@ class Worker(BaseCommand):
             cursor.execute("SET application_name TO %s", ['dpq#{}'.format(os.getpid())])
 
         if self.listen:
+            self.logger.info('Listening for queued tasks', extra={
+                'channel': self.queue.notify_channel,
+            })
             self.queue.listen()
         try:
 


### PR DESCRIPTION
I thought it would be a neat addition to support auto-reload like `django-admin runserver` does. That is usually what you want while developing.