### PR TITLE
Adapt test project to Django 2.0 and above

### DIFF
--- a/testproj/urls.py
+++ b/testproj/urls.py
@@ -13,7 +13,12 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    # django < 2.0
+    from django.conf.urls import url
+
 from django.contrib import admin
 
 urlpatterns = [


### PR DESCRIPTION
I noticed that the testproj doesn't work with Django 2.0 or newer so I fixed that. Django 1.11 also doesn't support anything above Python 3.7 it might be time to drop support for all Django versions below 3.2 since it's the oldest LTS version.